### PR TITLE
Fix homologação 2018-06-08

### DIFF
--- a/Controller/Checkout/Exchange.php
+++ b/Controller/Checkout/Exchange.php
@@ -30,9 +30,14 @@ class Exchange extends \Magento\Framework\App\Action\Action
 
 	public function execute()
 	{
+		$installments = (int)$this->getRequest()->getParam('installments');
 		$result = $this->resultJsonFactory->create();
         $base_total = $this->_session->getQuote()->getBaseGrandTotal();
         $country = $this->_session->getQuote()->getBillingAddress()->getCountryId();
+
+		if($installments > 1){
+			$base_total = $this->_ebanxHelper->calculateTotalWithInterest($base_total, $installments);
+		}
 
         $integrationKey = $this->_ebanxHelper->getConfigData('digitalhub_ebanx_global', 'live_integration_key');
         $sandboxIntegrationKey = $this->_ebanxHelper->getConfigData('digitalhub_ebanx_global', 'sandbox_integration_key');

--- a/Controller/CreditCard/Installments.php
+++ b/Controller/CreditCard/Installments.php
@@ -37,7 +37,7 @@ class Installments extends \Magento\Framework\App\Action\Action
 		foreach(range(1,$maxInstallments) as $number){
 			$total_with_interest = $this->ebanxHelper->calculateTotalWithInterest($total, $number);
 			$installment_total = $total_with_interest / $number;
-			if($installment_total < $minInstallmentValue) continue;
+			if($installment_total < $minInstallmentValue && $number > 1) continue;
 
 			$installments[] = [
 				'number' => $number,

--- a/Controller/OneClickPayment/PlaceOrder.php
+++ b/Controller/OneClickPayment/PlaceOrder.php
@@ -49,7 +49,7 @@ class PlaceOrder extends \Magento\Framework\App\Action\Action
 			$quote->getPayment()->importData([
 				'method' => $postData->payment_method,
 				'additional_data' => [
-					'document_number' => '',
+					'document_number' => $postData->documentNumber,
 					'use_saved_cc' => $postData->token_id,
 					'installments' => 1
 				]

--- a/Test/Unit/Controller/Checkout/ExchangeTest.php
+++ b/Test/Unit/Controller/Checkout/ExchangeTest.php
@@ -26,6 +26,7 @@ class ExchangeTest extends \PHPUnit\Framework\TestCase
         $amountTotalConvertedWithIof = $amountTotalConverted + ($amountTotalConverted * 0.0038);
 
         $context = $this->getMockBuilder(\Magento\Framework\App\Action\Context::class)
+            ->setMethods(['getRequest'])
             ->disableOriginalConstructor()
             ->getMock();
         $resultJsonFactory = $this->getMockBuilder(\Magento\Framework\Controller\Result\JsonFactory::class)
@@ -50,6 +51,12 @@ class ExchangeTest extends \PHPUnit\Framework\TestCase
             ->setMethods(['getCurrency','toCurrency','getDefaultCurrency'])
             ->disableOriginalConstructor()
             ->getMock();
+
+        $context->expects($this->once())
+            ->method('getRequest')
+            ->willReturn(new \Magento\Framework\DataObject([
+                'param' => 1
+            ]));
 
         $currency->expects($this->any())
             ->method('getCurrency')
@@ -273,6 +280,7 @@ class ExchangeTest extends \PHPUnit\Framework\TestCase
         $amountTotalConvertedWithIof = $amountTotalConverted + ($amountTotalConverted * 0.0038);
 
         $context = $this->getMockBuilder(\Magento\Framework\App\Action\Context::class)
+            ->setMethods(['getRequest'])
             ->disableOriginalConstructor()
             ->getMock();
         $resultJsonFactory = $this->getMockBuilder(\Magento\Framework\Controller\Result\JsonFactory::class)
@@ -302,6 +310,12 @@ class ExchangeTest extends \PHPUnit\Framework\TestCase
             ->method('getCurrency')
             ->with('BRL')
             ->willReturn($currency);
+
+        $context->expects($this->once())
+            ->method('getRequest')
+            ->willReturn(new \Magento\Framework\DataObject([
+                'param' => 1
+            ]));
 
         $currency->expects($this->any())
             ->method('getDefaultCurrency')

--- a/Test/Unit/Controller/CreditCard/InstallmentsTest.php
+++ b/Test/Unit/Controller/CreditCard/InstallmentsTest.php
@@ -183,7 +183,14 @@ class InstallmentsTest extends \PHPUnit\Framework\TestCase
                 ],
                 'expected' => [
                     'success' => false,
-                    'installments' => []
+                    'installments' => [
+                        [
+                            'number' => 1,
+                            'installment_value' => 0,
+                            'total_with_interest' => 0,
+                            'interest' => 0
+                        ]
+                    ]
                 ]
             ],
             [
@@ -199,6 +206,24 @@ class InstallmentsTest extends \PHPUnit\Framework\TestCase
                             'number' => 1,
                             'installment_value' => 100,
                             'total_with_interest' => 100,
+                            'interest' => 0
+                        ]
+                    ]
+                ]
+            ],
+            [
+                'requested' => [
+                    'max_installments' => 5,
+                    'min_installment_value' => 50,
+                    'total' => 35
+                ],
+                'expected' => [
+                    'success' => true,
+                    'installments' => [
+                        [
+                            'number' => 1,
+                            'installment_value' => 35,
+                            'total_with_interest' => 35,
                             'interest' => 0
                         ]
                     ]

--- a/Test/Unit/Controller/OneClickPayment/PlaceOrderTest.php
+++ b/Test/Unit/Controller/OneClickPayment/PlaceOrderTest.php
@@ -15,6 +15,7 @@ class PlaceOrderTest extends \PHPUnit\Framework\TestCase
             'cart_id' => $quoteId,
             'shipping_address_id' => $shippingAddressId,
             'payment_method' => $paymentMethod,
+            'documentNumber' => null,
             'token_id' => $tokenId,
         ]);
 
@@ -216,6 +217,7 @@ class PlaceOrderTest extends \PHPUnit\Framework\TestCase
             'cart_id' => $quoteId,
             'shipping_address_id' => $shippingAddressId,
             'payment_method' => $paymentMethod,
+            'documentNumber' => null,
             'token_id' => $tokenId,
         ]);
 

--- a/Test/Unit/Gateway/Validator/Argentina/CreditCard/CountryValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/Argentina/CreditCard/CountryValidatorTest.php
@@ -90,12 +90,6 @@ class CountryValidatorTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
-        $storeManager->expects($this->once())
-            ->method('getStore')
-            ->willReturn(new \Magento\Framework\DataObject([
-                'base_currency_code' => 'USD'
-            ]));
-
         $validationSubject = [
             'country' => 'PE',
             'storeId' => 1

--- a/Test/Unit/Gateway/Validator/Argentina/CuponDePagos/CountryValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/Argentina/CuponDePagos/CountryValidatorTest.php
@@ -89,13 +89,7 @@ class CountryValidatorTest extends \PHPUnit\Framework\TestCase
             ->setMethods(['getStore'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
-
-        $storeManager->expects($this->once())
-            ->method('getStore')
-            ->willReturn(new \Magento\Framework\DataObject([
-                'base_currency_code' => 'USD'
-            ]));
-
+        
         $validationSubject = [
             'country' => 'PE',
             'storeId' => 1

--- a/Test/Unit/Gateway/Validator/Argentina/PagoFacil/CountryValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/Argentina/PagoFacil/CountryValidatorTest.php
@@ -89,13 +89,7 @@ class CountryValidatorTest extends \PHPUnit\Framework\TestCase
             ->setMethods(['getStore'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
-
-        $storeManager->expects($this->once())
-            ->method('getStore')
-            ->willReturn(new \Magento\Framework\DataObject([
-                'base_currency_code' => 'USD'
-            ]));
-
+            
         $validationSubject = [
             'country' => 'PE',
             'storeId' => 1

--- a/Test/Unit/Gateway/Validator/Argentina/Rapipago/CountryValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/Argentina/Rapipago/CountryValidatorTest.php
@@ -89,13 +89,7 @@ class CountryValidatorTest extends \PHPUnit\Framework\TestCase
             ->setMethods(['getStore'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
-
-        $storeManager->expects($this->once())
-            ->method('getStore')
-            ->willReturn(new \Magento\Framework\DataObject([
-                'base_currency_code' => 'USD'
-            ]));
-
+            
         $validationSubject = [
             'country' => 'PE',
             'storeId' => 1

--- a/Test/Unit/Gateway/Validator/Brazil/Boleto/CountryValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/Brazil/Boleto/CountryValidatorTest.php
@@ -90,12 +90,6 @@ class CountryValidatorTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
-        $storeManager->expects($this->once())
-            ->method('getStore')
-            ->willReturn(new \Magento\Framework\DataObject([
-                'base_currency_code' => 'USD'
-            ]));
-
         $validationSubject = [
             'country' => 'PE',
             'storeId' => 1

--- a/Test/Unit/Gateway/Validator/Brazil/CreditCard/CountryValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/Brazil/CreditCard/CountryValidatorTest.php
@@ -90,12 +90,6 @@ class CountryValidatorTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
-        $storeManager->expects($this->once())
-            ->method('getStore')
-            ->willReturn(new \Magento\Framework\DataObject([
-                'base_currency_code' => 'USD'
-            ]));
-
         $validationSubject = [
             'country' => 'PE',
             'storeId' => 1

--- a/Test/Unit/Gateway/Validator/Brazil/EbanxAccount/CountryValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/Brazil/EbanxAccount/CountryValidatorTest.php
@@ -90,12 +90,6 @@ class CountryValidatorTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
-        $storeManager->expects($this->once())
-            ->method('getStore')
-            ->willReturn(new \Magento\Framework\DataObject([
-                'base_currency_code' => 'USD'
-            ]));
-
         $validationSubject = [
             'country' => 'PE',
             'storeId' => 1

--- a/Test/Unit/Gateway/Validator/Brazil/Tef/CountryValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/Brazil/Tef/CountryValidatorTest.php
@@ -89,13 +89,7 @@ class CountryValidatorTest extends \PHPUnit\Framework\TestCase
             ->setMethods(['getStore'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
-
-        $storeManager->expects($this->once())
-            ->method('getStore')
-            ->willReturn(new \Magento\Framework\DataObject([
-                'base_currency_code' => 'USD'
-            ]));
-
+            
         $validationSubject = [
             'country' => 'PE',
             'storeId' => 1

--- a/Test/Unit/Gateway/Validator/Chile/Multicaja/CountryValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/Chile/Multicaja/CountryValidatorTest.php
@@ -90,12 +90,6 @@ class CountryValidatorTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
-        $storeManager->expects($this->once())
-            ->method('getStore')
-            ->willReturn(new \Magento\Framework\DataObject([
-                'base_currency_code' => 'USD'
-            ]));
-
         $validationSubject = [
             'country' => 'PE',
             'storeId' => 1

--- a/Test/Unit/Gateway/Validator/Chile/Sencillito/CountryValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/Chile/Sencillito/CountryValidatorTest.php
@@ -89,13 +89,7 @@ class CountryValidatorTest extends \PHPUnit\Framework\TestCase
             ->setMethods(['getStore'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
-
-        $storeManager->expects($this->once())
-            ->method('getStore')
-            ->willReturn(new \Magento\Framework\DataObject([
-                'base_currency_code' => 'USD'
-            ]));
-
+            
         $validationSubject = [
             'country' => 'PE',
             'storeId' => 1

--- a/Test/Unit/Gateway/Validator/Chile/Servipag/CountryValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/Chile/Servipag/CountryValidatorTest.php
@@ -90,12 +90,6 @@ class CountryValidatorTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
-        $storeManager->expects($this->once())
-            ->method('getStore')
-            ->willReturn(new \Magento\Framework\DataObject([
-                'base_currency_code' => 'USD'
-            ]));
-
         $validationSubject = [
             'country' => 'PE',
             'storeId' => 1

--- a/Test/Unit/Gateway/Validator/Chile/Webpay/CountryValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/Chile/Webpay/CountryValidatorTest.php
@@ -90,12 +90,6 @@ class CountryValidatorTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
-        $storeManager->expects($this->once())
-            ->method('getStore')
-            ->willReturn(new \Magento\Framework\DataObject([
-                'base_currency_code' => 'USD'
-            ]));
-
         $validationSubject = [
             'country' => 'PE',
             'storeId' => 1

--- a/Test/Unit/Gateway/Validator/Colombia/Baloto/CountryValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/Colombia/Baloto/CountryValidatorTest.php
@@ -90,12 +90,6 @@ class CountryValidatorTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
-        $storeManager->expects($this->once())
-            ->method('getStore')
-            ->willReturn(new \Magento\Framework\DataObject([
-                'base_currency_code' => 'USD'
-            ]));
-
         $validationSubject = [
             'country' => 'PE',
             'storeId' => 1

--- a/Test/Unit/Gateway/Validator/Colombia/CreditCard/CountryValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/Colombia/CreditCard/CountryValidatorTest.php
@@ -90,12 +90,6 @@ class CountryValidatorTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
-        $storeManager->expects($this->once())
-            ->method('getStore')
-            ->willReturn(new \Magento\Framework\DataObject([
-                'base_currency_code' => 'USD'
-            ]));
-
         $validationSubject = [
             'country' => 'PE',
             'storeId' => 1

--- a/Test/Unit/Gateway/Validator/Colombia/Eft/CountryValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/Colombia/Eft/CountryValidatorTest.php
@@ -90,12 +90,6 @@ class CountryValidatorTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
-        $storeManager->expects($this->once())
-            ->method('getStore')
-            ->willReturn(new \Magento\Framework\DataObject([
-                'base_currency_code' => 'USD'
-            ]));
-
         $validationSubject = [
             'country' => 'PE',
             'storeId' => 1

--- a/Test/Unit/Gateway/Validator/Ecuador/SafetyPay/CountryValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/Ecuador/SafetyPay/CountryValidatorTest.php
@@ -90,12 +90,6 @@ class CountryValidatorTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
-        $storeManager->expects($this->once())
-            ->method('getStore')
-            ->willReturn(new \Magento\Framework\DataObject([
-                'base_currency_code' => 'USD'
-            ]));
-
         $validationSubject = [
             'country' => 'PE',
             'storeId' => 1

--- a/Test/Unit/Gateway/Validator/Mexico/CreditCard/CountryValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/Mexico/CreditCard/CountryValidatorTest.php
@@ -90,12 +90,6 @@ class CountryValidatorTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
-        $storeManager->expects($this->once())
-            ->method('getStore')
-            ->willReturn(new \Magento\Framework\DataObject([
-                'base_currency_code' => 'USD'
-            ]));
-
         $validationSubject = [
             'country' => 'PE',
             'storeId' => 1

--- a/Test/Unit/Gateway/Validator/Mexico/Oxxo/CountryValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/Mexico/Oxxo/CountryValidatorTest.php
@@ -90,12 +90,6 @@ class CountryValidatorTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
-        $storeManager->expects($this->once())
-            ->method('getStore')
-            ->willReturn(new \Magento\Framework\DataObject([
-                'base_currency_code' => 'USD'
-            ]));
-
         $validationSubject = [
             'country' => 'PE',
             'storeId' => 1

--- a/Test/Unit/Gateway/Validator/Mexico/Spei/CountryValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/Mexico/Spei/CountryValidatorTest.php
@@ -90,12 +90,6 @@ class CountryValidatorTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
-        $storeManager->expects($this->once())
-            ->method('getStore')
-            ->willReturn(new \Magento\Framework\DataObject([
-                'base_currency_code' => 'USD'
-            ]));
-
         $validationSubject = [
             'country' => 'PE',
             'storeId' => 1

--- a/Test/Unit/Gateway/Validator/Peru/PagoEfectivo/CountryValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/Peru/PagoEfectivo/CountryValidatorTest.php
@@ -90,12 +90,6 @@ class CountryValidatorTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
-        $storeManager->expects($this->once())
-            ->method('getStore')
-            ->willReturn(new \Magento\Framework\DataObject([
-                'base_currency_code' => 'USD'
-            ]));
-
         $validationSubject = [
             'country' => 'BR',
             'storeId' => 1

--- a/Test/Unit/Gateway/Validator/Peru/SafetyPay/CountryValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/Peru/SafetyPay/CountryValidatorTest.php
@@ -90,12 +90,6 @@ class CountryValidatorTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
-        $storeManager->expects($this->once())
-            ->method('getStore')
-            ->willReturn(new \Magento\Framework\DataObject([
-                'base_currency_code' => 'USD'
-            ]));
-
         $validationSubject = [
             'country' => 'BR',
             'storeId' => 1

--- a/view/frontend/templates/product/view/oneclickpayment.phtml
+++ b/view/frontend/templates/product/view/oneclickpayment.phtml
@@ -1,3 +1,7 @@
+<script type="text/javascript">
+    window.oneClickPaymentMagentoBaseUrl = '<?php echo $this->getUrl('/') ?>';
+</script>
+
 <div id="digitalhub-ebanx-oneclickpayment" data-bind="scope: 'ebanx_oneclickpayment'" style="display: none">
     <!-- ko template: getTemplate() --><!-- /ko -->
 </div>

--- a/view/frontend/web/js/action/document-number-verification.js
+++ b/view/frontend/web/js/action/document-number-verification.js
@@ -1,12 +1,9 @@
 define(
     [
         'mage/storage',
-        'mage/url',
-        'Magento_Checkout/js/model/quote'
+        'mage/url'
     ],
-    function (storage, url, quote) {
-        'use strict';
-
+    function (storage, url) {
         return function () {
             return storage.post(url.build('digitalhub_ebanx/checkout/documentverification'), false)
         };

--- a/view/frontend/web/js/action/oneclickpayment/session-check.js
+++ b/view/frontend/web/js/action/oneclickpayment/session-check.js
@@ -5,8 +5,8 @@ define(
     ],
     function (storage, url) {
         'use strict';
-
         return function () {
+            url.setBaseUrl(window.oneClickPaymentMagentoBaseUrl);
             return storage.get(url.build('digitalhub_ebanx/oneclickpayment/sessioncheck'), false)
         };
     }

--- a/view/frontend/web/js/action/total-local-currency.js
+++ b/view/frontend/web/js/action/total-local-currency.js
@@ -8,7 +8,8 @@ define(
         'use strict';
 
         return function () {
-            return storage.get(url.build('digitalhub_ebanx/checkout/exchange'), false)
+            var installments = arguments[0] && parseInt(arguments[0]) || 1;
+            return storage.get(url.build('digitalhub_ebanx/checkout/exchange?installments=' + installments), false)
         };
     }
 );

--- a/view/frontend/web/js/oneclickpayment/component.js
+++ b/view/frontend/web/js/oneclickpayment/component.js
@@ -11,7 +11,8 @@ define([
     'DigitalHub_Ebanx/js/action/saved-cards',
     'Magento_Ui/js/modal/modal',
     'mage/translate',
-    'Magento_Ui/js/modal/alert'
+    'Magento_Ui/js/modal/alert',
+    'DigitalHub_Ebanx/js/action/document-number-verification'
 ], function(
     _,
     Component,
@@ -26,7 +27,7 @@ define([
     modal,
     $t,
     alert,
-    customer
+    documentNumberVerification
 ) {
     'use strict';
     return Component.extend({
@@ -40,6 +41,8 @@ define([
             billingAddressId: null,
             shippingMethod: null,
             paymentMethod: null,
+            documentNumber: null,
+            showDocumentField: null,
             orderIncrementId: null,
             successPage: false,
             useSavedCard: null
@@ -55,6 +58,8 @@ define([
                     'shippingAddressId',
                     'billingAddressId',
                     'shippingMethod',
+                    'documentNumber',
+                    'showDocumentField',
                     'paymentMethod',
                     'orderIncrementId',
                     'successPage',
@@ -141,6 +146,11 @@ define([
                 self.shippingAddressList(list)
             });
 
+            // document number verification
+            $.when(documentNumberVerification()).done(function(result){
+                self.showDocumentField(!result.has_document_number)
+            });
+
             // populate shipping method List when shipping address changes
             this.shippingAddressId.subscribe(function(shipping_address_id){
                 self.shippingMethod(null)
@@ -203,6 +213,7 @@ define([
                 shipping_address_id: this.shippingAddressId(),
                 shipping_method: this.shippingMethod(),
                 payment_method: this.paymentMethod(),
+                documentNumber: this.documentNumber(),
                 token_id: this.useSavedCard()
             }
 

--- a/view/frontend/web/js/view/payment/argentina/method-renderer/creditcard.js
+++ b/view/frontend/web/js/view/payment/argentina/method-renderer/creditcard.js
@@ -122,6 +122,11 @@ define(
                         })
                     })
 
+                    self.creditCardInstallments.subscribe(function(value){
+                        self.totalLocalCurrency(null);
+                        self.calculateTotalLocalCurrency(value);
+                    })
+
                     self.availableInstallments(installmentsOptions)
 
                 }).always(function () {
@@ -155,14 +160,14 @@ define(
                     // after all
                 });
 
-                $.when(totalLocalCurrency()).done(function (result) {
-                    if(self.getGlobalConfig().show_iof && result.total_with_iof_formatted){
-                        var text = $t('Total amount in local currency with IOF (0.38%):');
-                        self.totalLocalCurrency(text + ' ' + result.total_with_iof_formatted);
-                    } else {
-                        var text = $t('Total amount in local currency:');
-                        self.totalLocalCurrency(text + ' ' + result.total_formatted);
-                    }
+                self.calculateTotalLocalCurrency();
+            },
+
+            calculateTotalLocalCurrency: function(installments){
+                var self = this;
+                $.when(totalLocalCurrency(installments)).done(function (result) {
+                    var text = $t('Total amount in local currency:');
+                    self.totalLocalCurrency(text + ' ' + result.total_formatted);
                 });
             },
 

--- a/view/frontend/web/js/view/payment/brazil/method-renderer/creditcard.js
+++ b/view/frontend/web/js/view/payment/brazil/method-renderer/creditcard.js
@@ -120,6 +120,11 @@ define(
                         })
                     })
 
+                    self.creditCardInstallments.subscribe(function(value){
+                        self.totalLocalCurrency(null);
+                        self.calculateTotalLocalCurrency(value);
+                    })
+
                     self.availableInstallments(installmentsOptions)
 
                 }).always(function () {
@@ -153,7 +158,12 @@ define(
                     // after all
                 });
 
-                $.when(totalLocalCurrency()).done(function (result) {
+                self.calculateTotalLocalCurrency();
+            },
+
+            calculateTotalLocalCurrency: function(installments){
+                var self = this;
+                $.when(totalLocalCurrency(installments)).done(function (result) {
                     if(self.getGlobalConfig().show_iof && result.total_with_iof_formatted){
                         var text = $t('Total amount in local currency with IOF (0.38%):');
                         self.totalLocalCurrency(text + ' ' + result.total_with_iof_formatted);

--- a/view/frontend/web/js/view/payment/colombia/method-renderer/creditcard.js
+++ b/view/frontend/web/js/view/payment/colombia/method-renderer/creditcard.js
@@ -120,6 +120,11 @@ define(
                         })
                     })
 
+                    self.creditCardInstallments.subscribe(function(value){
+                        self.totalLocalCurrency(null);
+                        self.calculateTotalLocalCurrency(value);
+                    })
+
                     self.availableInstallments(installmentsOptions)
 
                 }).always(function () {
@@ -153,14 +158,14 @@ define(
                     // after all
                 });
 
-                $.when(totalLocalCurrency()).done(function (result) {
-                    if(self.getGlobalConfig().show_iof && result.total_with_iof_formatted){
-                        var text = $t('Total amount in local currency with IOF (0.38%):');
-                        self.totalLocalCurrency(text + ' ' + result.total_with_iof_formatted);
-                    } else {
-                        var text = $t('Total amount in local currency:');
-                        self.totalLocalCurrency(text + ' ' + result.total_formatted);
-                    }
+                self.calculateTotalLocalCurrency();
+            },
+
+            calculateTotalLocalCurrency: function(installments){
+                var self = this;
+                $.when(totalLocalCurrency(installments)).done(function (result) {
+                    var text = $t('Total amount in local currency:');
+                    self.totalLocalCurrency(text + ' ' + result.total_formatted);
                 });
             },
 

--- a/view/frontend/web/js/view/payment/mexico/method-renderer/creditcard.js
+++ b/view/frontend/web/js/view/payment/mexico/method-renderer/creditcard.js
@@ -137,6 +137,11 @@ define(
                         })
                     })
 
+                    self.creditCardInstallments.subscribe(function(value){
+                        self.totalLocalCurrency(null);
+                        self.calculateTotalLocalCurrency(value);
+                    })
+
                     self.availableInstallments(installmentsOptions)
 
                 }).always(function () {
@@ -170,14 +175,14 @@ define(
                     // after all
                 });
 
-                $.when(totalLocalCurrency()).done(function (result) {
-                    if(self.getGlobalConfig().show_iof && result.total_with_iof_formatted){
-                        var text = $t('Total amount in local currency with IOF (0.38%):');
-                        self.totalLocalCurrency(text + ' ' + result.total_with_iof_formatted);
-                    } else {
-                        var text = $t('Total amount in local currency:');
-                        self.totalLocalCurrency(text + ' ' + result.total_formatted);
-                    }
+                self.calculateTotalLocalCurrency();
+            },
+
+            calculateTotalLocalCurrency: function(installments){
+                var self = this;
+                $.when(totalLocalCurrency(installments)).done(function (result) {
+                    var text = $t('Total amount in local currency:');
+                    self.totalLocalCurrency(text + ' ' + result.total_formatted);
                 });
             },
 

--- a/view/frontend/web/template/oneclickpayment/container.html
+++ b/view/frontend/web/template/oneclickpayment/container.html
@@ -58,7 +58,20 @@
                 </div>
             <!-- /ko -->
 
-            <!-- ko if: useSavedCard() -->
+            <!-- ko if: showDocumentField() -->
+                <div class="field required">
+                    <label class="label">
+                        <span><!-- ko i18n: 'Document number'--><!-- /ko --> <em>*</em></span>
+                    </label>
+                    <div class="control">
+                        <input type="text" name="oneclickpayment[document_number]"
+                            data-validate="{'required-entry': true}"
+                            data-bind="value: documentNumber, valueUpdate: 'afterkeydown'">
+                    </div>
+                </div>
+            <!-- /ko -->
+
+            <!-- ko if: useSavedCard() && ((showDocumentField() && documentNumber()) || !showDocumentField()) -->
             <div class="field">
                 <button class="action primary" data-bind="click: placeOrder">
                     <!-- ko i18n: 'Place Order'--><!-- /ko -->


### PR DESCRIPTION
Fix para as seguintes situações:

* 1-Click não pede documento e retorna `Field payment.document is required`
* Quando a config de valor mínimo de instalment ultrapassa o valor do produto, nenhuma opção aparece para ser selecionada e o pagamento não passa. 1x deveria aparecer sempre.
* Quando uma instalment com interest é selecionada no checkout o `Total amount in local currency:` não atualiza para o novo valor total