### PR TITLE
Correções para atualização de notificações de pagamento

### DIFF
--- a/Gateway/Response/Brazil/EbanxAccount/AuthorizationHandler.php
+++ b/Gateway/Response/Brazil/EbanxAccount/AuthorizationHandler.php
@@ -39,7 +39,7 @@ class AuthorizationHandler implements HandlerInterface
         $payment->setAdditionalInformation('transaction_data', $payment_result_data);
 
         // set transaction not to processing by default wait for notification
-        $payment->setIsTransactionPending(false);
+        $payment->setIsTransactionPending(true);
 
         // no not send order confirmation mail
         $payment->getOrder()->setCanSendNewEmailFlag(false);

--- a/Gateway/Response/Chile/Multicaja/AuthorizationHandler.php
+++ b/Gateway/Response/Chile/Multicaja/AuthorizationHandler.php
@@ -36,7 +36,7 @@ class AuthorizationHandler implements HandlerInterface
         $payment->setAdditionalInformation('transaction_data', $payment_result_data);
 
         // set transaction not to processing by default wait for notification
-        $payment->setIsTransactionPending(false);
+        $payment->setIsTransactionPending(true);
 
         // no not send order confirmation mail
         $payment->getOrder()->setCanSendNewEmailFlag(false);

--- a/Gateway/Response/Chile/Sencillito/AuthorizationHandler.php
+++ b/Gateway/Response/Chile/Sencillito/AuthorizationHandler.php
@@ -39,7 +39,7 @@ class AuthorizationHandler implements HandlerInterface
         $payment->setAdditionalInformation('transaction_data', $payment_result_data);
 
         // set transaction not to processing by default wait for notification
-        $payment->setIsTransactionPending(false);
+        $payment->setIsTransactionPending(true);
 
         // no not send order confirmation mail
         $payment->getOrder()->setCanSendNewEmailFlag(false);

--- a/Gateway/Response/Chile/Servipag/AuthorizationHandler.php
+++ b/Gateway/Response/Chile/Servipag/AuthorizationHandler.php
@@ -39,7 +39,7 @@ class AuthorizationHandler implements HandlerInterface
         $payment->setAdditionalInformation('transaction_data', $payment_result_data);
 
         // set transaction not to processing by default wait for notification
-        $payment->setIsTransactionPending(false);
+        $payment->setIsTransactionPending(true);
 
         // no not send order confirmation mail
         $payment->getOrder()->setCanSendNewEmailFlag(false);

--- a/Gateway/Response/Chile/Webpay/AuthorizationHandler.php
+++ b/Gateway/Response/Chile/Webpay/AuthorizationHandler.php
@@ -39,7 +39,7 @@ class AuthorizationHandler implements HandlerInterface
         $payment->setAdditionalInformation('transaction_data', $payment_result_data);
 
         // set transaction not to processing by default wait for notification
-        $payment->setIsTransactionPending(false);
+        $payment->setIsTransactionPending(true);
 
         // no not send order confirmation mail
         $payment->getOrder()->setCanSendNewEmailFlag(false);

--- a/Gateway/Response/Colombia/Baloto/AuthorizationHandler.php
+++ b/Gateway/Response/Colombia/Baloto/AuthorizationHandler.php
@@ -39,7 +39,7 @@ class AuthorizationHandler implements HandlerInterface
         $payment->setAdditionalInformation('transaction_data', $payment_result_data);
 
         // set transaction not to processing by default wait for notification
-        $payment->setIsTransactionPending(false);
+        $payment->setIsTransactionPending(true);
 
         // no not send order confirmation mail
         $payment->getOrder()->setCanSendNewEmailFlag(false);

--- a/Gateway/Response/Colombia/Eft/AuthorizationHandler.php
+++ b/Gateway/Response/Colombia/Eft/AuthorizationHandler.php
@@ -39,7 +39,7 @@ class AuthorizationHandler implements HandlerInterface
         $payment->setAdditionalInformation('transaction_data', $payment_result_data);
 
         // set transaction not to processing by default wait for notification
-        $payment->setIsTransactionPending(false);
+        $payment->setIsTransactionPending(true);
 
         // no not send order confirmation mail
         $payment->getOrder()->setCanSendNewEmailFlag(false);

--- a/Gateway/Response/Ecuador/SafetyPay/AuthorizationHandler.php
+++ b/Gateway/Response/Ecuador/SafetyPay/AuthorizationHandler.php
@@ -39,7 +39,7 @@ class AuthorizationHandler implements HandlerInterface
         $payment->setAdditionalInformation('transaction_data', $payment_result_data);
 
         // set transaction not to processing by default wait for notification
-        $payment->setIsTransactionPending(false);
+        $payment->setIsTransactionPending(true);
 
         // no not send order confirmation mail
         $payment->getOrder()->setCanSendNewEmailFlag(false);

--- a/Gateway/Response/Mexico/Oxxo/AuthorizationHandler.php
+++ b/Gateway/Response/Mexico/Oxxo/AuthorizationHandler.php
@@ -39,7 +39,7 @@ class AuthorizationHandler implements HandlerInterface
         $payment->setAdditionalInformation('transaction_data', $payment_result_data);
 
         // set transaction not to processing by default wait for notification
-        $payment->setIsTransactionPending(false);
+        $payment->setIsTransactionPending(true);
 
         // no not send order confirmation mail
         $payment->getOrder()->setCanSendNewEmailFlag(false);

--- a/Gateway/Response/Mexico/Spei/AuthorizationHandler.php
+++ b/Gateway/Response/Mexico/Spei/AuthorizationHandler.php
@@ -39,7 +39,7 @@ class AuthorizationHandler implements HandlerInterface
         $payment->setAdditionalInformation('transaction_data', $payment_result_data);
 
         // set transaction not to processing by default wait for notification
-        $payment->setIsTransactionPending(false);
+        $payment->setIsTransactionPending(true);
 
         // no not send order confirmation mail
         $payment->getOrder()->setCanSendNewEmailFlag(false);

--- a/Gateway/Response/Peru/PagoEfectivo/AuthorizationHandler.php
+++ b/Gateway/Response/Peru/PagoEfectivo/AuthorizationHandler.php
@@ -39,7 +39,7 @@ class AuthorizationHandler implements HandlerInterface
         $payment->setAdditionalInformation('transaction_data', $payment_result_data);
 
         // set transaction not to processing by default wait for notification
-        $payment->setIsTransactionPending(false);
+        $payment->setIsTransactionPending(true);
 
         // no not send order confirmation mail
         $payment->getOrder()->setCanSendNewEmailFlag(false);

--- a/Gateway/Response/Peru/SafetyPay/AuthorizationHandler.php
+++ b/Gateway/Response/Peru/SafetyPay/AuthorizationHandler.php
@@ -39,7 +39,7 @@ class AuthorizationHandler implements HandlerInterface
         $payment->setAdditionalInformation('transaction_data', $payment_result_data);
 
         // set transaction not to processing by default wait for notification
-        $payment->setIsTransactionPending(false);
+        $payment->setIsTransactionPending(true);
 
         // no not send order confirmation mail
         $payment->getOrder()->setCanSendNewEmailFlag(false);


### PR DESCRIPTION
- Troca de status do pedido para processing, quando em payment_review, após o recebimento da notificação de atualização do status. Isso permite que o pedido seja processado automaticamente via notificação de status.
- Alteração de flag is_transaction_pending para false em outros métodos de Cash Payment. Isso permitirá que os pedidos de Cash Payment não entrem inicialmente com o status processing.